### PR TITLE
Move OreDict registration to after GameRegistry registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
 *.class
 
+eclipse/
+
+*.iml
+*.ipr
+*.iws
+
+.gradle/
+
+out/
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/src/main/java/fox/spiteful/avaritia/items/ItemResource.java
+++ b/src/main/java/fox/spiteful/avaritia/items/ItemResource.java
@@ -36,9 +36,6 @@ public class ItemResource extends Item implements IHaloRenderItem {
         this.setMaxDamage(0);
         this.setUnlocalizedName("avaritia_resource");
         this.setCreativeTab(Avaritia.tab);
-        OreDictionary.registerOre("ingotCrystalMatrix", new ItemStack(this, 1, 1));
-        OreDictionary.registerOre("ingotCosmicNeutronium", new ItemStack(this, 1, 4));
-        OreDictionary.registerOre("ingotInfinity", new ItemStack(this, 1, 6));
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/fox/spiteful/avaritia/items/LudicrousItems.java
+++ b/src/main/java/fox/spiteful/avaritia/items/LudicrousItems.java
@@ -8,11 +8,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemFood;
+import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.EnumHelper;
+import net.minecraftforge.oredict.OreDictionary;
 
 import static net.minecraft.item.Item.ToolMaterial;
 
@@ -75,6 +77,9 @@ public class LudicrousItems {
     public static void grind(){
         resource = new ItemResource();
         GameRegistry.registerItem(resource, "Resource");
+        OreDictionary.registerOre("ingotCrystalMatrix", new ItemStack(resource, 1, 1));
+        OreDictionary.registerOre("ingotCosmicNeutronium", new ItemStack(resource, 1, 4));
+        OreDictionary.registerOre("ingotInfinity", new ItemStack(resource, 1, 6));
 
         if(Config.craftingOnly)
             return;


### PR DESCRIPTION
Move `OreDictionary` registration of `ItemResource` variants to after `GameRegistry` registration.
Fixes #55
Also add run dir, .gradle and IDEA files to .gitignore