### PR TITLE
Create zh_CN.lang

### DIFF
--- a/src/main/resources/assets/avaritia/lang/zh_CN.lang
+++ b/src/main/resources/assets/avaritia/lang/zh_CN.lang
@@ -1,0 +1,165 @@
+#
+# Items
+item.avaritia_resource.diamond_lattice.name=钻石晶格
+item.avaritia_resource.crystal_matrix_ingot.name=水晶矩阵锭
+item.avaritia_resource.neutron_pile.name=中子素尘埃
+item.avaritia_resource.neutron_nugget.name=中子素颗粒
+item.avaritia_resource.neutronium_ingot.name=中子锭
+item.avaritia_resource.infinity_catalyst.name=无尽催化剂
+item.avaritia_resource.infinity_ingot.name=无尽之锭
+item.avaritia_resource.record_fragment.name=唱片碎片
+item.singularity_iron.name=奇点-铁
+item.singularity_gold.name=奇点-金
+item.singularity_lapis.name=奇点-青金石
+item.singularity_redstone.name=奇点-红石
+item.singularity_quartz.name=奇点-下界石英
+item.singularity_copper.name=奇点-铜
+item.singularity_tin.name=奇点-锡
+item.singularity_lead.name=奇点-铅
+item.singularity_silver.name=奇点-银
+item.singularity_nickel.name=奇点-镍
+item.infinity_pickaxe.name=世界崩解之镐
+item.infinity_sword.name=寰宇支配之剑
+item.infinity_shovel.name=星球吞噬之铲
+item.infinity_axe.name=自然荒芜之斧
+item.infinity_bow.name=天堂陨落长弓
+item.skullfire_sword.name=炽焰之啄颅剑
+item.akashic_record.name=阿卡西记录
+item.orb_armok.name=阿蒙克气血宝珠
+item.avaritia_stew.name=超级煲
+item.avaritia_meatballs.name=寰宇肉丸
+item.avaritia_endest_pearl.name=终望珍珠
+item.infinity_armor_0.name=无尽头盔
+item.infinity_armor_1.name=无尽胸甲
+item.infinity_armor_2.name=无尽护腿
+item.infinity_armor_3.name=无尽靴子
+item.avaritia_fracturedore.name=Unknown Fractured Ore
+item.avaritia_fracturedore.prefix=Fractured
+item.avaritia_mattercluster.name=物质团
+item.avaritia_mattercluster.full.name=Critical Matter Cluster
+item.morvinabox.name=Morv-In-A-Box (WIP)(WILL LIGHT YOU ON FIRE)
+item.avaritia.comb.nerfed.name=削弱蜂巢
+item.avaritia.comb.cosmic.name=寰宇蜂巢
+item.avaritia_beesource.infinity_drop.name=无尽蜜汁
+item.avaritia_beesource.dust.name=粉尘
+#
+# Blocks
+tile.compressed_workbench.name=压缩工作台
+tile.very_compressed_workbench.name=二重压缩工作台
+tile.block_crystal_matrix.name=水晶矩阵
+tile.block_neutronium.name=中子态素块
+tile.block_infinity.name=无尽之块
+tile.block_gaia.name=盖亚块
+tile.dire_crafting.name=终极工作台
+tile.neutron_collector.name=中子态素收集器
+tile.neutronium_compressor.name=中子态素压缩机
+tile.infinitato.name=无尽小土豆
+tile.alfheim_deadrock0.name=死岩
+tile.alfheim_deadrock1.name=死岩砖
+tile.alfheim_deadrock2.name=苔死岩砖
+tile.alfheim_deadrock3.name=裂死岩砖
+tile.alfheim_deadrock4.name=錾制死岩砖
+#
+# Tooltips
+tooltip.armok.desc=手持时可存储无限的原始生命本质。
+tooltip.crystal_matrix_ingot.desc=这甚至不是最终形态。
+tooltip.neutron_pile.desc=尽量不要去想它。
+tooltip.neutron_nugget.desc=大约3560万吨吧。
+tooltip.neutronium_ingot.desc=致密恒星之心，化为一锭。
+tooltip.infinity_catalyst.desc=一即全，全即一。
+tooltip.infinity_ingot.desc=汝掌心中者，寰宇之力也。
+tooltip.record_fragment.desc=一位笃信音乐带来的自由的人~
+tooltip.skullfire_sword.desc=斩骷髅首级，后烧至焦黑。
+tooltip.matter_cluster.desc=用于毁灭一切。
+tooltip.matter_cluster.desc2=按下SHIFT显示详细信息。
+tooltip.matter_cluster.counter=物品
+tooltip.morvinabox.desc=即时住房。
+tooltip.morvinabox.subdesc=在加拿大，Morvy是成袋装的。
+#
+# Achievements
+achievement.avaritia:crystal_matrix=第一枚纹章
+achievement.avaritia:crystal_matrix.desc=制造第一个水晶矩阵锭
+achievement.avaritia:dire_crafting=HELLO, EVERYONE!
+achievement.avaritia:dire_crafting.desc=用普通工作台合成终极工作台
+achievement.avaritia:dire_uncrafting=TAKE IT EASY!
+achievement.avaritia:dire_uncrafting.desc=终章之尾(于是又是一集Direwolf20结束了)
+achievement.avaritia:collector=然后就是挂机时代
+achievement.avaritia:collector.desc=制造一台中子态素收集器，然后准备好世界锚挂机吧
+achievement.avaritia:neutronium=去**的挂机
+achievement.avaritia:neutronium.desc=合成第一批中子素锭
+achievement.avaritia:singularity=事件视界
+achievement.avaritia:singularity.desc=制造你第一个奇点
+achievement.avaritia:catalyst=所有厨房的水池
+achievement.avaritia:catalyst.desc=制造你第一个无尽催化剂
+achievement.avaritia:infinity=INFINITE POWER!
+achievement.avaritia:infinity.desc=制造你第一个无尽之锭
+achievement.avaritia:armok=☺♦
+achievement.avaritia:armok.desc=制造那属于阿蒙克的气血宝珠
+achievement.avaritia:creative_kill=甚至上帝也会流血
+achievement.avaritia:creative_kill.desc="因罪而堕落的天使"
+#
+# Misc
+itemGroup.avaritia=Avaritia
+container.neutron_collector=中子态素收集器
+container.neutronium_compressor=中子态素压缩机
+tc.aspect.terminus=游戏之终结,启示录,天启,粉碎一切
+crafting.extreme=有序终极合成
+crafting.extreme.shapeless=无序终极合成
+crafting.extreme_compression=中子态素压缩机
+tip.infinity=Infinity
+death.attack.infinity=%1$s被%2$s彻底粉碎
+death.attack.infinity.item=%1$s被%2$s彻底粉碎
+death.attack.infinity.1=%1$s被%2$s切成了条
+death.attack.infinity.2=%1$s被%2$s抹杀了存在
+death.attack.infinity.3=%1$s被%2$s赶尽杀绝
+death.attack.infinity.4=%1$s被%2$s所湮灭
+#
+# Botania
+avaritia.flower.asgardandelion.name=阿斯加德蒲公英
+tile.botania:flower.asgardandelion.name=阿斯加德蒲公英
+tile.avaritia.flower.asgardandelion.lore=以Vazkii的泪水浇灌 :c
+avaritia.lexicon.asgardandelion=阿斯加德蒲公英
+avaritia.lexicon.asgardandelion.0=有这样一个笑话，是说一种接 近神之力的花，她可以产生无 穷无尽的mana。如果这花 真的存在于这世上，那这花所 需要的财富和资源的数量，恐 怕是穷尽人类毕生也无法算 完的。<br>&o然而这和刀剑神域并无关系。&r
+avaritia.lexicon.infinitato=无尽小土豆
+avaritia.lexicon.infinitato.0=将万物之精华印在一个东西上 可以导致一些有趣的结果，这 个无尽迷你土豆也不例外。<br>比普通的小土豆稍大，冠以 名为&1小土豆&0和&1无尽之催化剂 &0两重名号，这&1无尽小土豆&0相 信你能做到任何事情，永远都 会。
+avaritia.lexicon.infinitato.1=相信我，&o它的确合适。&r
+avaritia.flower.soarleander.name=Soarleander
+tile.botania:flower.soarleander.name=Soarleander
+tile.avaritia.flower.soarleander.lore=Just hook it up to my &oveeeeins!&r
+avaritia.lexicon.soarleander=Soarleander
+avaritia.lexicon.soarleander.0=If you have a surfeit of chicken or chicken by-products, look no further!<br>The Soarleander will devour any and all things chicken in the vicinity (chickens themselves included) while remaining totally disinterested in everything else.
+avaritia.lexicon.soarleander.1=&oAny random chests are an unintended side-effect.&r
+#
+# Thaumcraft
+item.Wand.infinity.rod=宇宙中子态素
+item.Wand.matrix.cap=水晶缠绕
+#
+# Tinkers Construct
+material.avaritia_neutronium=宇宙中子素
+material.avaritia_neutronium.ability=千斤坠沉
+material.avaritia_infinitymetal=无尽
+material.avaritia_infinitymetal.ability=寰宇
+#
+# Beeeeeeeeeeeees
+avaritia.bee.annoying=嘈杂
+avaritia.bee.annoying.desc="它们到底要多久才能弄个蜂窝?!"|古代时间胶囊里的笔记
+avaritia.bee.tedious=冗长
+avaritia.bee.tedious.desc=它们的蜂巢其实是由更小的蜂巢组合而成的,这些小蜂巢又是由更小的蜂巢组合而成的...
+avaritia.bee.insufferable=不可忍受
+avaritia.bee.insufferable.desc=They often sabotage other bees they perceive as having any advantages or improper vocabulary.
+avaritia.bee.trippy=幻象
+avaritia.bee.trippy.desc="这家伙。怎么说呢...就是蜜蜂。真是。它们真是...棒极了。"|SpitefulFox,无牌照养蜂人
+avaritia.bee.cosmic=寰宇
+avaritia.bee.cosmic.desc=
+avaritia.bee.neutronium=中子
+avaritia.bee.neutronium.desc=它们的蜂巢附近总可以找到些环绕其运行的小东西。
+avaritia.bee.infinite=无尽
+avaritia.bee.infinite.desc=
+
+classification.balanced=平衡
+classification.balanced.desc=这些深感厌倦的蜜蜂，在它们的使命结束前的一刻彻底放弃了一切。它们会用最长也最繁杂的方式来保持放松。
+classification.infinite=无尽
+classification.infinite.desc=它们从隐藏的“龙脉”以及宇宙本身的奥法能量中汲取所谓的“生命能量”(般那)。
+
+avaritia.allele.speedNerfed=削弱
+avaritia.allele.lifespanArtificial=人造


### PR DESCRIPTION
Ugh, I think that's 90% translated. Some entries have no translation, either because that object has no actual usage or because I am not sure about the reference, like `Soarleander`. 
Ah, 'Avaritia', as the mod name, isn't translated which is on purpose.

> Someone tell me that Soarlender references to Soaryn, original author of Xycraft. Is he correct? 

Also I have two more questions onb translation:
1. does that '*one is all and all is one*' references to *Fullmetal Alchemist*
2. does that '*Armok*' reference to *Slaves to Armok: God of Blood.* 

Last but not least: thanks for your time!